### PR TITLE
Add response object to knatch methods

### DIFF
--- a/src/knatch/quarto.py
+++ b/src/knatch/quarto.py
@@ -2,6 +2,7 @@ import os
 import math
 import argparse
 import logging
+import requests
 
 from knatch import put_with_retries, patch_with_retries
 
@@ -48,7 +49,7 @@ def batch_upload_quarto(
     path: str = "quarto/update",
     batch_size: int = 10,
     ignore_extensions: list = [],
-):
+) -> requests.Response:
   if not os.getcwd().endswith(folder):
       os.chdir(folder)
 
@@ -75,6 +76,7 @@ def batch_upload_quarto(
         else:
             res = patch_with_retries(f"https://{host}/{path}/{quarto_id}", multipart_form_data, team_token)
 
+        _ = res
         res.raise_for_status()
 
         uploaded = end_batch if end_batch < len(files["regular_files"]) else len(files["regular_files"])
@@ -93,10 +95,11 @@ def batch_upload_quarto(
         else:
             res = patch_with_retries(f"https://{host}/{path}/{quarto_id}", multipart_form_data, team_token)
 
+        _ = res
         res.raise_for_status()
 
         logging.info(f"Uploaded {idx+1}/{len(files['large_files'])} large files")
-
+  return _
 
 def batch_update():
     parser = argparse.ArgumentParser(description="Knatch - knada batch")

--- a/src/knatch/utils.py
+++ b/src/knatch/utils.py
@@ -3,12 +3,12 @@ import requests
 
 
 @backoff.on_exception(backoff.expo, (requests.exceptions.RequestException, requests.exceptions.HTTPError), max_tries=8)
-def put_with_retries(url, multipart_form_data, token):
+def put_with_retries(url, multipart_form_data, token) -> requests.Response:
   return requests.put(url, headers={"Authorization": f"Bearer {token}"},
                       files=multipart_form_data)
 
 
 @backoff.on_exception(backoff.expo, (requests.exceptions.RequestException, requests.exceptions.HTTPError), max_tries=8)
-def patch_with_retries(url, multipart_form_data, token):
+def patch_with_retries(url, multipart_form_data, token) -> requests.Response:
   return requests.patch(url, headers={"Authorization": f"Bearer {token}"},
                         files=multipart_form_data)


### PR DESCRIPTION
I think Knatch should expose the `requests.Response` object to knatch methods such as `batch_upload_quarto` in order to make debugging easier.

